### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "payments-webhook-node",
   "version": "0.0.1",
+  "engines": {
+    "node": "0.8.28"
+  },
   "dependencies": {
     "express": "2.5.6",
     "dnode": "0.9.6",


### PR DESCRIPTION
If running the app on Heroku you need to specify the version of Node to use in the package.json. Later versions of Node do not work with this app.